### PR TITLE
update dependencies to the latest releases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
-scalaVersion := "2.12.1"
+scalaVersion := "2.13.3"
 
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-free" % "0.9.0",
-  "org.scalatest" %% "scalatest" % "3.0.1" % Test,
+  "org.typelevel" %% "cats-free" % "2.3.0",
+  "org.scalatest" %% "scalatest" % "3.2.2" % Test,
 
   "org.scala-lang" % "scala-compiler" % scalaVersion.value // for REPLesent
 )

--- a/presentation.txt
+++ b/presentation.txt
@@ -1,4 +1,4 @@
-val pres = REPLesent(80, 25, slideCounter=true, slideTotal=true, intp=$intp)
+val pres = REPLesent(80, 25, slideCounter=true, slideTotal=true)
 import pres._
 
 import cats.~>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.4.4

--- a/src/main/scala/REPLesent.scala
+++ b/src/main/scala/REPLesent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Marconi Lanna
+ * Copyright 2015-2017 Marconi Lanna
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ case class REPLesent(
 , source: String = "REPLesent.txt"
 , slideCounter: Boolean = false
 , slideTotal: Boolean = false
+, padNewline: Boolean = false
 , intp: scala.tools.nsc.interpreter.IMain = null
 ) {
   import java.io.File
@@ -52,7 +53,7 @@ case class REPLesent(
         } getOrElse Array(0, 0)
 
         val screenWidth = Seq(width, w) find (_ > 0) getOrElse defaultWidth
-        val screenHeight = Seq(height, h) find (_ > 0) getOrElse defaultHeight
+        val screenHeight = Seq(height, h - (if (padNewline) 1 else 0)) find (_ > 0) getOrElse defaultHeight
 
         (screenWidth, screenHeight)
       }
@@ -246,7 +247,7 @@ case class REPLesent(
 
     private lazy val emojis: Map[String, String] = {
       Try {
-        val emoji = io.Source.fromFile("emoji.txt").getLines
+        val emoji = scala.io.Source.fromFile("emoji.txt").getLines
         emoji.map { l =>
           val a = l.split(' ')
           (a(1), a(0))
@@ -383,10 +384,10 @@ case class REPLesent(
             .list
             .sorted
             .filter(_.endsWith(".replesent"))
-            .flatMap { name => io.Source.fromFile(new File(pathFile, name)).getLines }
+            .flatMap { name => scala.io.Source.fromFile(new File(pathFile, name)).getLines }
             .toIterator
         } else {
-          io.Source.fromFile(path).getLines
+          scala.io.Source.fromFile(path).getLines
         }
       )
       parse(lines)
@@ -563,6 +564,7 @@ case class REPLesent(
     build foreach { b =>
       print(render(b))
     }
+    if (padNewline) print("\n\n\u001b[2A") // Create a space for if the user enters "n\n", to keep the screen from jumping
   }
   private def reloadDeck(): Unit = {
     val curSlide = deck.currentSlideNumber

--- a/src/main/scala/free/modular/dsls.scala
+++ b/src/main/scala/free/modular/dsls.scala
@@ -2,11 +2,12 @@ package free.modular
 
 import common._
 
-import cats.free.{Free, Inject}
+import cats.InjectK
+import cats.free.Free
 
 object DSL {
 
-  class DynamoOps[F[_]](implicit I: Inject[DynamoAlg, F]) {
+  class DynamoOps[F[_]](implicit I: InjectK[DynamoAlg, F]) {
 
     def insertDynamoRecord(id: PhotoId, s3key: S3Key, createdBy: String): Free[F, DynamoRecord] = 
       Free.inject[DynamoAlg, F](InsertDynamoRecord(id, s3key, createdBy))
@@ -17,10 +18,10 @@ object DSL {
   }
 
   object DynamoOps {
-    implicit def dynamoOps[F[_]](implicit I: Inject[DynamoAlg, F]): DynamoOps[F] = new DynamoOps[F]
+    implicit def dynamoOps[F[_]](implicit I: InjectK[DynamoAlg, F]): DynamoOps[F] = new DynamoOps[F]
   }
 
-  class S3Ops[F[_]](implicit I: Inject[S3Alg, F]) {
+  class S3Ops[F[_]](implicit I: InjectK[S3Alg, F]) {
 
     def generateS3Key(id: PhotoId): Free[F, S3Key] =
       Free.inject[S3Alg, F](GenerateS3Key(id))
@@ -34,7 +35,7 @@ object DSL {
   }
 
   object S3Ops {
-    implicit def s3Ops[F[_]](implicit I: Inject[S3Alg, F]): S3Ops[F] = new S3Ops[F]
+    implicit def s3Ops[F[_]](implicit I: InjectK[S3Alg, F]): S3Ops[F] = new S3Ops[F]
   }
 
 

--- a/src/main/scala/free/modular/package.scala
+++ b/src/main/scala/free/modular/package.scala
@@ -1,7 +1,7 @@
 package free.modular
 
+import cats.data.EitherK
 import cats.data.OptionT
-import cats.data.Coproduct
 import cats.free.Free
 
 import scala.concurrent.Future
@@ -10,8 +10,7 @@ object `package` {
 
   type FutureOfOption[A] = OptionT[Future, A]
 
-  // Note: Coproduct will be called EitherK in cats 1.0
-  type Algebra[A] = Coproduct[S3Alg, DynamoAlg, A]
+  type Algebra[A] = EitherK[S3Alg, DynamoAlg, A]
 
   type Program[A] = Free[Algebra, A]
 

--- a/src/test/scala/free/test.scala
+++ b/src/test/scala/free/test.scala
@@ -8,8 +8,10 @@ import cats.data.Writer
 import cats.instances.list._
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class FreeTest extends FlatSpec with Matchers {
+class FreeTest extends AnyFlatSpec with Matchers {
 
   import Programs._
 

--- a/src/test/scala/tagless/test.scala
+++ b/src/test/scala/tagless/test.scala
@@ -4,8 +4,10 @@ import common._
 
 import cats._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class TaglessFinalTest extends FlatSpec with Matchers {
+class TaglessFinalTest extends AnyFlatSpec with Matchers {
 
   def testAlgebra(
     dynamo: Map[PhotoId, DynamoRecord],


### PR DESCRIPTION
This is one of the best if not the best and the only good reference for a comparison of free and tagless-final using cats in Scala. 

Needed an update to move with the times.

Also tried to do justice to REPLeasent. Had to drop `intp=$intp` from the `presetation.txt` - an attempt at providing another interpreter. But the README didn't hint at how to use that one, so just dropped it.

